### PR TITLE
Switch input source to en when switching to vim's normal mode

### DIFF
--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -689,6 +689,54 @@
                         ]
                     },
                     {
+                        "description": "[Vim/Vim emulator] Switch input source to english when starting normal mode",
+                        "manipulators": [
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.jetbrains\\.",
+                                            "^com\\.apple\\.Terminal$",
+                                            "^md\\.obsidian$"
+                                        ],
+                                        "type": "frontmost_application_if"
+                                    },
+                                    {
+                                        "input_sources": [
+                                            {
+                                                "language": "en"
+                                            }
+                                        ],
+                                        "type": "input_source_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "key_code": "open_bracket",
+                                    "modifiers": {
+                                        "mandatory": [
+                                            "left_control"
+                                        ]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "c",
+                                        "modifiers": [
+                                            "right_control"
+                                        ]
+                                    },
+                                    {
+                                        "key_code": "spacebar",
+                                        "modifiers": [
+                                            "left_control"
+                                        ]
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
                         "description": "Launch applications",
                         "manipulators": [
                             {


### PR DESCRIPTION
When using vim (or its emulator) with a non-`en` input source, this is a bit cumbersome when switching from insert mode to normal mode because one also has to switch the input source to `en` to use commands. Below is an example describing a scenario where one switches to normal mode and inputs `k` multiple times to move the cursor, but actually ends up with `ja` characters because the input source is still `ja`.

![image](https://user-images.githubusercontent.com/1629963/212055258-055bbf76-7947-4962-b00f-da4cc7a60b25.png)

Thinking of the context, this is obvious that the input source should be `en` when one enters normal mode because its commands only work with the `en` input source. This is rare that the input source is non-`en` when coding on IDE's with vim key bindings. However, this is vital when using vim emulation with note-taking apps such as Obsidian.

This P-R tries to change the input source to `en` when one switches to the normal mode. Because this works for both the built-in Macbook keyboard and external keyboard, the changes are applied to the Karabiner-Elements configuration rather than the `qmk_firmware` repository.

Candidate shortcuts are as below:
- Esc ... Has more impact since `esc` is a commonly used key. As long as we can't specify a condition such as "only applicable when `insert mode` is selected," this should be avoided.
- Ctrl + [ ... Acts in the same way as `esc`. This is the first pick.
- Ctrl + c ... This also works to change the mode but behaves a bit differently. Probably this is a good time to apply the change to `Ctrl + [` only and get used to it.

Target apps:
- Terminal ( ^com\.apple\.Terminal$ )
  - We can't detect if Vim is used with Karabiner-Elements, but the work on `Ctrl + [` wouldn't affect the regular use cases. 
- Jetbrains products（ ^com\.jetbrains\. ）
- Obsidian ( ^md\.obsidian$ )